### PR TITLE
Update ci.yml (Fix Node.js warnings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           generate_release_notes: true
+          append_body: false
           tag_name: 'preview'
           prerelease: true
           name: 'preview'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          generate_release_notes: true
-          append_body: false
           tag_name: 'preview'
           prerelease: true
           name: 'preview'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
 
-      - uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
 
-      - name: Install JDK
-        uses: actions/setup-java@v2
+      - name: Install JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: 17
+          distribution: temurin
           cache: gradle
 
       - name: Grant execute permission for gradlew
@@ -33,10 +35,11 @@ jobs:
         run: ./gradlew assemble
 
       - name: Create preview release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: 'preview'
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          generate_release_notes: true
+          tag_name: 'preview'
           prerelease: true
-          title: 'preview'
+          name: 'preview'
           files: app/build/outputs/apk/fdroidSelfSigned/release/app-*.apk

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
Changes:
Added [gradle/actions/wrapper-validation](https://github.com/gradle/actions/#the-wrapper-validation-action) to verify [gradle-wrapper.jar](https://github.com/teambtcmap/btcmap-android/blob/master/gradle/wrapper/gradle-wrapper.jar)
Updated [actions/checkout](https://github.com/actions/checkout) to v4 (v3 use EOL Node.js)
Updated [actions/setup-java]() to v4 (v2 use EOL Node.js)
Replaced deprecated and unsupported [marvinpinto/action-automatic-releases](https://github.com/marvinpinto/action-automatic-releases) with [softprops/action-gh-release](https://github.com/softprops/action-gh-release)

Added distributionSha256Sum in [gradle-wrapper.properties](https://github.com/teambtcmap/btcmap-android/blob/master/gradle/wrapper/gradle-wrapper.properties) to verify gradle-x.y-bin.zip
In the future, use a similar command to update:
```
gradlew wrapper --gradle-version 8.7 --gradle-distribution-sha256-sum 544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
```
Hash sums for gradle releases can always be found [here](https://gradle.org/release-checksums)


Node.js 16 EOL (End Of Life) - [GitHub.Blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
