### PR TITLE
draft: relabel option to show atms to also mention exchanges

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -48,7 +48,7 @@
     <string name="category_pub_plural">Kneipen</string>
     <string name="category_restaurant">Restaurant</string>
     <string name="category_restaurant_plural">Restaurants</string>
-    <string name="show_atms">Geldautomaten anzeigen</string>
+    <string name="show_atms">Geldautomaten / Wechselstuben anzeigen</string>
     <string name="pay_onchain">Pay Onchain</string>
     <string name="pay_with_lightning">Pay with Lightning</string>
     <string name="image">Image</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="category_pub_plural">Pubs</string>
     <string name="category_restaurant">Restaurant</string>
     <string name="category_restaurant_plural">Restaurants</string>
-    <string name="show_atms">Show ATMs</string>
+    <string name="show_atms">Show ATMs / Exchanges</string>
     <string name="pay_onchain">Pay Onchain</string>
     <string name="pay_with_lightning">Pay with Lightning</string>
     <string name="image">Image</string>


### PR DESCRIPTION
depends on merge of: https://github.com/teambtcmap/btcmap-api/pull/38

incl. money exchanges (amenity:bureau_de_change) with atm for optional visibility in settings for partial fix on https://github.com/teambtcmap/btcmap.org/issues/56